### PR TITLE
Remove as a dynamic library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,6 @@ let package = Package(
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "ConfettiSwiftUI",
-            type: .dynamic,
             targets: ["ConfettiSwiftUI"]),
     ],
     dependencies: [


### PR DESCRIPTION
### Description

This causes code signing issues when attempting to archive and sign inside of Xcode Cloud. As far as I can tell, setting the library to be dynamic isn't needed. I tested using this line removed and it gets built and functions properly in the built app.

### Related Issues

https://github.com/simibac/ConfettiSwiftUI/issues/8
