### PR TITLE
Add option to skip animation when the counter decreases

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,21 +96,22 @@ struct ContentView: View {
 
 ### Parameters
 
-| parameter          | type           | description                                           | default                                                                                              |
-| ------------------ | -------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| counter            | Binding<Int>   | on any change of this variable triggers the animation | 0                                                                                                    |
-| num                | Int            | amount of confettis                                   | 20                                                                                                   |
-| confettis          | [ConfettiType] | list of shapes and text                               | [.shape(.circle), .shape(.triangle), .shape(.square), .shape(.slimRectangle), .shape(.roundedCross)] |
-| colors             | [Color]        | list of colors applied to the default shapes          | [.blue, .red, .green, .yellow, .pink, .purple, .orange]                                              |
-| confettiSize       | CGFloat        | size that confettis and emojis are scaled to          | 10.0                                                                                                 |
-| rainHeight         | CGFloat        | vertical distance that confettis pass                 | 600.0                                                                                                |
-| fadesOut           | Bool           | size that confettis and emojis are scaled to          | true                                                                                                 |
-| opacity            | Double         | maximum opacity during the animation                  | 1.0                                                                                                  |
-| openingAngle       | Angle          | boundary that defines the opening angle in degrees    | Angle.degrees(60)                                                                                    |
-| closingAngle       | Angle          | boundary that defines the closing angle in degrees    | Angle.degrees(120)                                                                                   |
-| radius             | CGFloat        | explosion radius                                      | 300.0                                                                                                |
-| repetitions        | Int            | number of repetitions for the explosion               | 0                                                                                                    |
-| repetitionInterval | Double         | duration between the repetitions                      | 1.0                                                                                                  |
+| parameter             | type           | description                                             | default                                                                                              |
+| --------------------- | -------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| counter               | Binding<Int>   | on any change of this variable triggers the animation   | 0                                                                                                    |
+| num                   | Int            | amount of confettis                                     | 20                                                                                                   |
+| confettis             | [ConfettiType] | list of shapes and text                                 | [.shape(.circle), .shape(.triangle), .shape(.square), .shape(.slimRectangle), .shape(.roundedCross)] |
+| colors                | [Color]        | list of colors applied to the default shapes            | [.blue, .red, .green, .yellow, .pink, .purple, .orange]                                              |
+| confettiSize          | CGFloat        | size that confettis and emojis are scaled to            | 10.0                                                                                                 |
+| rainHeight            | CGFloat        | vertical distance that confettis pass                   | 600.0                                                                                                |
+| fadesOut              | Bool           | size that confettis and emojis are scaled to            | true                                                                                                 |
+| opacity               | Double         | maximum opacity during the animation                    | 1.0                                                                                                  |
+| openingAngle          | Angle          | boundary that defines the opening angle in degrees      | Angle.degrees(60)                                                                                    |
+| closingAngle          | Angle          | boundary that defines the closing angle in degrees      | Angle.degrees(120)                                                                                   |
+| radius                | CGFloat        | explosion radius                                        | 300.0                                                                                                |
+| repetitions           | Int            | number of repetitions for the explosion                 | 0                                                                                                    |
+| repetitionInterval    | Double         | duration between the repetitions                        | 1.0                                                                                                  |
+| ignoreCounterDecrease | Bool           | option to skip the animation when the counter decreases | false                                                                                                |
 
 ### Configurator Application With Live Preview
 

--- a/Sources/ConfettiSwiftUI/ConfettiSwiftUI.swift
+++ b/Sources/ConfettiSwiftUI/ConfettiSwiftUI.swift
@@ -78,7 +78,8 @@ public struct ConfettiCannon: View {
          closingAngle:Angle = .degrees(120),
          radius:CGFloat = 300,
          repetitions:Int = 0,
-         repetitionInterval:Double = 1.0
+         repetitionInterval:Double = 1.0,
+         ignoreCounterDecrease:Bool = false
          
     ) {
         self._counter = counter
@@ -107,7 +108,8 @@ public struct ConfettiCannon: View {
             closingAngle: closingAngle,
             radius: radius,
             repetitions: repetitions,
-            repetitionInterval: repetitionInterval
+            repetitionInterval: repetitionInterval,
+            ignoreCounterDecrease: ignoreCounterDecrease
         ))
     }
 
@@ -123,8 +125,12 @@ public struct ConfettiCannon: View {
         .onAppear(){
             firtAppear = true
         }
-        .onChange(of: counter){value in
+        .onChange(of: counter){ [oldValue = counter] value in
             guard firtAppear else { return }
+
+            if confettiConfig.ignoreCounterDecrease, value < oldValue {
+                return
+            }
 
             for i in 0...confettiConfig.repetitions{
                 DispatchQueue.main.asyncAfter(deadline: .now() + confettiConfig.repetitionInterval * Double(i)) {
@@ -247,7 +253,7 @@ struct ConfettiAnimationView: View {
 }
 
 class ConfettiConfig: ObservableObject {
-    internal init(num: Int, shapes: [AnyView], colors: [Color], confettiSize: CGFloat, rainHeight: CGFloat, fadesOut: Bool, opacity: Double, openingAngle:Angle, closingAngle:Angle, radius:CGFloat, repetitions:Int, repetitionInterval:Double) {
+    internal init(num: Int, shapes: [AnyView], colors: [Color], confettiSize: CGFloat, rainHeight: CGFloat, fadesOut: Bool, opacity: Double, openingAngle:Angle, closingAngle:Angle, radius:CGFloat, repetitions:Int, repetitionInterval:Double, ignoreCounterDecrease:Bool) {
         self.num = num
         self.shapes = shapes
         self.colors = colors
@@ -262,6 +268,7 @@ class ConfettiConfig: ObservableObject {
         self.repetitionInterval = repetitionInterval
         self.explosionAnimationDuration = Double(radius / 1500)
         self.rainAnimationDuration = Double((rainHeight + radius) / 200)
+        self.ignoreCounterDecrease = ignoreCounterDecrease
     }
     
     @Published var num:Int
@@ -278,6 +285,7 @@ class ConfettiConfig: ObservableObject {
     @Published var repetitionInterval:Double
     @Published var explosionAnimationDuration:Double
     @Published var rainAnimationDuration:Double
+    @Published var ignoreCounterDecrease:Bool
 
     
     var animationDuration:Double{

--- a/Sources/ConfettiSwiftUI/ConfettiSwiftUI.swift
+++ b/Sources/ConfettiSwiftUI/ConfettiSwiftUI.swift
@@ -124,13 +124,13 @@ public struct ConfettiCannon: View {
             firtAppear = true
         }
         .onChange(of: counter){value in
-            if firtAppear{
-                for i in 0...confettiConfig.repetitions{
-                    DispatchQueue.main.asyncAfter(deadline: .now() + confettiConfig.repetitionInterval * Double(i)) {
-                        animate.append(false)
-                        if(value < animate.count){
-                            animate[value-1].toggle()
-                        }
+            guard firtAppear else { return }
+
+            for i in 0...confettiConfig.repetitions{
+                DispatchQueue.main.asyncAfter(deadline: .now() + confettiConfig.repetitionInterval * Double(i)) {
+                    animate.append(false)
+                    if(value < animate.count){
+                        animate[value-1].toggle()
                     }
                 }
             }


### PR DESCRIPTION
### Description

This PR adds the possibility to skip the confetti animation when the `$counter` value decreases compared to the previous value.

Imagine one has bound the `$counter` to the current score of a 'player' in any game where the score can in- and decrease. However, the animation should only be shown when the score increases. Having such a convenient configuration option to skip the animation might be helpful.

_I created the PR against `master` as the `develop` branch is behind the `master` branch._

### Related Issues

_No Issue created_

### Checklist

- [x] Have you added tests where necessary? Do all the test pass? 
  - There is only one test that doesn't really test the business code so I didn't add a new one as the testing facility is not properly set up for adding new meaningful tests
- [x] Have you added descriptive comments to your code?
- [x] Have you updated the documentation related to this propo
