### PR TITLE
Better Physics Simulation Option

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/ConfettiSwiftUI.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ConfettiSwiftUI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/ConfettiSwiftUI/ConfettiSwiftUI.swift
+++ b/Sources/ConfettiSwiftUI/ConfettiSwiftUI.swift
@@ -258,9 +258,9 @@ struct ConfettiAnimationView: View {
 
     
     @State var move = false
-    @State var xSpeed:Double = Double.random(in: 1.001...2.001)
+    @State var xSpeed:Double = Double.random(in: 0.501...2.201)
 
-    @State var zSpeed = Double.random(in: 1.001...2.001)
+    @State var zSpeed = Double.random(in: 0.501...2.201)
     @State var anchor = CGFloat.random(in: 0...1).rounded()
     
     var body: some View {

--- a/Sources/ConfettiSwiftUI/ConfettiSwiftUI.swift
+++ b/Sources/ConfettiSwiftUI/ConfettiSwiftUI.swift
@@ -78,8 +78,7 @@ public struct ConfettiCannon: View {
          closingAngle:Angle = .degrees(120),
          radius:CGFloat = 300,
          repetitions:Int = 0,
-         repetitionInterval:Double = 1.0,
-         realisticPhysics: Bool = false
+         repetitionInterval:Double = 1.0
     ) {
         self._counter = counter
         var shapes = [AnyView]()
@@ -107,8 +106,7 @@ public struct ConfettiCannon: View {
             closingAngle: closingAngle,
             radius: radius,
             repetitions: repetitions,
-            repetitionInterval: repetitionInterval,
-            realisticPhysics: realisticPhysics
+            repetitionInterval: repetitionInterval
         ))
     }
 
@@ -186,31 +184,19 @@ struct ConfettiView: View{
     }
     
     func getAnimationDuration() -> CGFloat {
-        if confettiConfig.realisticPhysics {
-            return 0.2 + confettiConfig.explosionAnimationDuration + getRandomExplosionTimeVariation()
-        } else {
-            return confettiConfig.explosionAnimationDuration
-        }
+        return 0.2 + confettiConfig.explosionAnimationDuration + getRandomExplosionTimeVariation()
     }
     
     func getAnimation() -> Animation {
-        if confettiConfig.realisticPhysics {
-            return Animation.timingCurve(0, 1, 0, 1, duration: getAnimationDuration())
-        } else {
-            return Animation.timingCurve(0.61, 1, 0.88, 1, duration: getAnimationDuration())
-        }
+        return Animation.timingCurve(0, 1, 0, 1, duration: getAnimationDuration())
     }
     
     func getDistance() -> CGFloat {
-        if confettiConfig.realisticPhysics {
-            return pow(CGFloat.random(in: 0.01...1), 2.0/7.0) * confettiConfig.radius
-        } else {
-            return CGFloat.random(in: 0.5...1) * confettiConfig.radius
-        }
+        return pow(CGFloat.random(in: 0.01...1), 2.0/7.0) * confettiConfig.radius
     }
     
     func getDelayBeforeRainAnimation() -> TimeInterval {
-        confettiConfig.explosionAnimationDuration * (confettiConfig.realisticPhysics ? 0.1 : 1)
+        confettiConfig.explosionAnimationDuration *  0.1
     }
 
     var body: some View{
@@ -280,7 +266,7 @@ struct ConfettiAnimationView: View {
 }
 
 class ConfettiConfig: ObservableObject {
-    internal init(num: Int, shapes: [AnyView], colors: [Color], confettiSize: CGFloat, rainHeight: CGFloat, fadesOut: Bool, opacity: Double, openingAngle:Angle, closingAngle:Angle, radius:CGFloat, repetitions:Int, repetitionInterval:Double, realisticPhysics:Bool) {
+    internal init(num: Int, shapes: [AnyView], colors: [Color], confettiSize: CGFloat, rainHeight: CGFloat, fadesOut: Bool, opacity: Double, openingAngle:Angle, closingAngle:Angle, radius:CGFloat, repetitions:Int, repetitionInterval:Double) {
         self.num = num
         self.shapes = shapes
         self.colors = colors
@@ -293,8 +279,7 @@ class ConfettiConfig: ObservableObject {
         self.radius = radius
         self.repetitions = repetitions
         self.repetitionInterval = repetitionInterval
-        self.realisticPhysics = realisticPhysics
-        self.explosionAnimationDuration = Double(radius / (realisticPhysics ? 1400 : 1500))
+        self.explosionAnimationDuration = Double(radius / 1400)
         self.rainAnimationDuration = Double((rainHeight + radius) / 200)
     }
     
@@ -310,7 +295,6 @@ class ConfettiConfig: ObservableObject {
     @Published var radius:CGFloat
     @Published var repetitions:Int
     @Published var repetitionInterval:Double
-    @Published var realisticPhysics:Bool
     @Published var explosionAnimationDuration:Double
     @Published var rainAnimationDuration:Double
 


### PR DESCRIPTION
### Description

Add the option to give realistic physics feel to the confetti. This consists mainly of adjusting the animation curve, overlapping confetti explosion animation with falling animation, and spreading confetti increasingly thinly towards the middle of the explosion.

Also expanded the range of confetti rotation values so they all don't appear to spin at the same time after the initial explosion.

### Checklist

- [x] All tests are passing
