### PR TITLE
Fix crash when app goes to background before animation is complete

### DIFF
--- a/Sources/ConfettiSwiftUI.swift
+++ b/Sources/ConfettiSwiftUI.swift
@@ -130,7 +130,7 @@ public struct ConfettiCannon: View {
                 for i in 0...confettiConfig.repetitions{
                     DispatchQueue.main.asyncAfter(deadline: .now() + confettiConfig.repetitionInterval * Double(i)) {
                         animate.append(false)
-                        if(value < animate.count){
+                        if(value > 0 && value < animate.count){
                             animate[value-1].toggle()
                         }
                     }


### PR DESCRIPTION
### Description

Making sure animation does not crash caused by index going out of range

### Related Issues

#22 Crash when app goes to background before animation is complete

### Checklist

- [ ] Have you added tests where necessary? Do all the test pass? 
- [ ] Have you added descriptive comments to your code?
- [ ] Have you updated the documentation related to this propo
