### PR TITLE
Fix typos in the code docs

### DIFF
--- a/Sources/ConfettiSwiftUI.swift
+++ b/Sources/ConfettiSwiftUI.swift
@@ -58,7 +58,7 @@ public struct ConfettiCannon: View {
     @State var firstAppear = false
     @State var error = ""
     
-    /// renders configurable confetti animaiton
+    /// renders configurable confetti animation
     /// - Parameters:
     ///   - counter: on any change of this variable the animation is run
     ///   - num: amount of confettis

--- a/Sources/View+ConfettiCannon.swift
+++ b/Sources/View+ConfettiCannon.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 public extension View {
     
-    /// renders configurable confetti animaiton
+    /// renders configurable confetti animation
     ///
     /// - Usage:
     ///


### PR DESCRIPTION
The word `animation` was misspelled in 2 locations. Both are comments and there will be no impact at the binary at all.