### PR TITLE
Add layoutPriority to self view

### DIFF
--- a/Sources/View+ConfettiCannon.swift
+++ b/Sources/View+ConfettiCannon.swift
@@ -61,7 +61,7 @@ public extension View {
 				hapticFeedback: Bool = true
     ) -> some View where T: Equatable {
         ZStack {
-            self
+            self.layoutPriority(1)
             ConfettiCannon(
                 trigger: trigger,
                 num: num,


### PR DESCRIPTION
Update View+ConfettiCannon.swift
Thanks for creating this package!
### Description

Add layoutPriority 1 to self view

### Related Issues

I encountered an issue earlier when the animation is triggered, the layout of the view that's attached to would be affected a little, and would come back when animation is done. 
Adding layoutPriority 1 to self view would make sure the self view layout won't be affected even when confetti animation is in progress.

Before fix:

https://github.com/user-attachments/assets/8724e2db-feec-423d-91b8-84d5a025c64b

After fix:

https://github.com/user-attachments/assets/7729c690-d94a-418f-9490-f27eeb36665d

### Checklist

- [x] Have you added tests where necessary? Do all the test pass? 
- [ ] Have you added descriptive comments to your code?
- [ ] Have you updated the documentation related to this propo
