### PR TITLE
Skip haptic feedback setup on tvOS

### DIFF
--- a/Sources/ConfettiSwiftUI.swift
+++ b/Sources/ConfettiSwiftUI.swift
@@ -139,7 +139,7 @@ public struct ConfettiCannon<T: Equatable>: View {
                 for i in 0..<confettiConfig.repetitions{
                     DispatchQueue.main.asyncAfter(deadline: .now() + confettiConfig.repetitionInterval * Double(i)) {
                         animate.append(false)
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(tvOS)
                         if confettiConfig.hapticFeedback {
                             let impactFeedback = UIImpactFeedbackGenerator(style: .heavy)
                             impactFeedback.impactOccurred()


### PR DESCRIPTION
### Description

`UIImpactFeedbackGenerator` is not supported on tvOS, and the build fails.

### Related Issues

Can't build for tvOS #60 

### Checklist

- [x] Have you added tests where necessary? Do all the test pass? 
- [x] Have you added descriptive comments to your code?
- [x] Have you updated the documentation related to this propo
