### PR TITLE
Fix failed to build for watchOS. Add haptics for watchOS

### DIFF
--- a/Sources/ConfettiSwiftUI.swift
+++ b/Sources/ConfettiSwiftUI.swift
@@ -139,7 +139,7 @@ public struct ConfettiCannon<T: Equatable>: View {
                 for i in 0..<confettiConfig.repetitions{
                     DispatchQueue.main.asyncAfter(deadline: .now() + confettiConfig.repetitionInterval * Double(i)) {
                         animate.append(false)
-#if canImport(UIKit) && !os(tvOS) && !os(visionOS)
+#if canImport(UIKit) && !os(tvOS) && !os(visionOS) && !os(watchOS)
                         if confettiConfig.hapticFeedback {
                             let impactFeedback = UIImpactFeedbackGenerator(style: .heavy)
                             impactFeedback.impactOccurred()
@@ -148,6 +148,11 @@ public struct ConfettiCannon<T: Equatable>: View {
                         if confettiConfig.hapticFeedback {
                             let impactFeedback = UIImpactFeedbackGenerator(style: .heavy)
                             impactFeedback.impactOccurred()
+                        }
+#elseif os(watchOS)
+                        if confettiConfig.hapticFeedback {
+                            let device = WKInterfaceDevice.current()
+                            device.play(.click)
                         }
 #endif
                     }


### PR DESCRIPTION
added haptics to watchOS

### Description

Currently it seems while building for watchOS; the platform check to apply haptics has not included the watchOS handling. Hence I have added the haptics for watch and also fixed the handling for UIImpactFeedbackGenerator to be excluded when build for watchOS

The haptics type for the watchOS used is `click` as it ain't too heavy while the animation occurs. But I think this can be changed as per preference.

<img width="3600" height="2252" alt="CleanShot 2025-07-31 at 08 55 44@2x" src="https://github.com/user-attachments/assets/04dca12d-6546-40c0-83ad-bf616380ec68" />

### Related Issue
[65](https://github.com/simibac/ConfettiSwiftUI/issues/65)