### PR TITLE
Allow ConfettiType.image to specify bundle

### DIFF
--- a/Sources/ConfettiSwiftUI.swift
+++ b/Sources/ConfettiSwiftUI.swift
@@ -20,7 +20,7 @@ public enum ConfettiType:CaseIterable, Hashable {
     case shape(Shape)
     case text(String)
     case sfSymbol(symbolName: String)
-    case image(String)
+    case image(String, bundle: Bundle? = nil)
     
     public var view:AnyView{
         switch self {
@@ -36,8 +36,12 @@ public enum ConfettiType:CaseIterable, Hashable {
             return AnyView(Text(text))
         case .sfSymbol(let symbolName):
             return AnyView(Image(systemName: symbolName))
-        case .image(let image):
-            return AnyView(Image(image).resizable())
+        case .image(let image, let bundle):
+            if let bundle {
+                return AnyView(Image(image, bundle: bundle).resizable())
+            } else {
+                return AnyView(Image(image).resizable())
+            }
         default:
             return AnyView(Circle())
         }


### PR DESCRIPTION
I do believe this applies to images in general within a swift package, however I am nearly certain this is needed for SVGs.

 SVGs are “supported” in iOS apps via a process step. If you are inside of a swift package and want to use a SVG with ConfettiUI you are unable to. This is because `Image(String)` within a swift package will not be able to find the image as it is processed by the package. To get this to work you need to add `resources: [Resource.process("Media.xcassets")]` to your package. This has the SVGs “processed” when the package is built (into what I do not know) and makes them accessible via`Image("image", bundle: packageBundle)`.

All this change is doing is adding an optional bundle argument to the image type of `ConfettiType` this way when you are in a package and wanting to use custom `ConfettiType` you can just specify the bundle!
 Attached is a quick test of this. There are two packages in the zip. One has this change, the other demonstrates having a svg for confetti and using this change to use it with `ConfettiUI`.


<img width="474" height="560" alt="Screenshot 2025-08-16 at 4 08 44 PM" src="https://github.com/user-attachments/assets/63d0f815-4bed-461a-bbf5-f1e56639e5ae" />

[Demo Packages.zip](https://github.com/user-attachments/files/21819326/Demo.Packages.zip)
