### PR TITLE
Require `Image` for `ConfettiType.image`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/Sources/ConfettiSwiftUI.swift
+++ b/Sources/ConfettiSwiftUI.swift
@@ -21,10 +21,10 @@ public enum ConfettiType:CaseIterable, Equatable {
     case text(String)
     case image(Image)
 
-    @available(*, deprecated, message: "Use the Image version of ConfettiType.image(_:) with Image(systemName:) instead")
+    @available(*, deprecated, message: "Use ConfettiType.image(_:) with Image(systemName:) instead")
     case sfSymbol(symbolName: String)
 
-    @available(*, deprecated, message: "Use the Image version of ConfettiType.image(_:) instead")
+    @available(*, deprecated, message: "Use ConfettiType.image(_:) with an Image instead")
     static func image(_ name: String) -> ConfettiType {
         return .image(Image(name))
     }

--- a/Sources/ConfettiSwiftUI.swift
+++ b/Sources/ConfettiSwiftUI.swift
@@ -7,8 +7,8 @@
 
 import SwiftUI
 
-public enum ConfettiType:CaseIterable, Hashable {
-    
+public enum ConfettiType:CaseIterable, Equatable {
+
     public enum Shape {
         case circle
         case triangle
@@ -19,27 +19,35 @@ public enum ConfettiType:CaseIterable, Hashable {
 
     case shape(Shape)
     case text(String)
+    case image(Image)
+
+    @available(*, deprecated, message: "Use the Image version of ConfettiType.image(_:) with Image(systemName:) instead")
     case sfSymbol(symbolName: String)
-    case image(String)
-    
-    public var view:AnyView{
+
+    @available(*, deprecated, message: "Use the Image version of ConfettiType.image(_:) instead")
+    static func image(_ name: String) -> ConfettiType {
+        return .image(Image(name))
+    }
+
+    @ViewBuilder
+    public var view: some View {
         switch self {
         case .shape(.square):
-            return AnyView(Rectangle())
+            Rectangle()
         case .shape(.triangle):
-            return AnyView(Triangle())
+            Triangle()
         case .shape(.slimRectangle):
-            return AnyView(SlimRectangle())
+            SlimRectangle()
         case .shape(.roundedCross):
-            return AnyView(RoundedCross())
+            RoundedCross()
         case let .text(text):
-            return AnyView(Text(text))
+            Text(text)
         case .sfSymbol(let symbolName):
-            return AnyView(Image(systemName: symbolName))
+            Image(systemName: symbolName)
         case .image(let image):
-            return AnyView(Image(image).resizable())
+            image.resizable()
         default:
-            return AnyView(Circle())
+            Circle()
         }
     }
     

--- a/Sources/ConfettiSwiftUI.swift
+++ b/Sources/ConfettiSwiftUI.swift
@@ -25,7 +25,7 @@ public enum ConfettiType:CaseIterable, Equatable {
     case sfSymbol(symbolName: String)
 
     @available(*, deprecated, message: "Use ConfettiType.image(_:) with an Image instead")
-    static func image(_ name: String) -> ConfettiType {
+    public static func image(_ name: String) -> ConfettiType {
         return .image(Image(name))
     }
 


### PR DESCRIPTION
Xcode can generate static symbols from xcassets automatically, but they can't be used with this library because `ConfettiType.image`'s input is currently a `String`. This PR changes the input type to `Image` instead:

```swift
// before (unsafe):
.confettiCannon(
  ...
  confettis: [.image("confetti")],
  ...
)
// after (safe):
.confettiCannon(
  ...
  confettis: [.image(Image(.confetti))],
  ...
)
```

I've deprecated the `String` and SFSymbol variants, but I'm happy to keep them if you so desire.