### PR TITLE
Add styled support for custom symbol assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,24 @@ You can use the configurator app in [demo project here](https://github.com/simib
 .confettiCannon(trigger: $trigger8, confettis: [.image("arb"), .image("eth"), .image("btc"), .image("op"), .image("link"), .image("doge")], confettiSize: 20)
 ```
 
+#### Custom Symbol Assets
+
+Use `.assetSymbol(symbolName:)` for symbol images that live in your app's asset
+catalog when you want them to pick up the same `foregroundColor` and
+`confettiSize` styling as `.sfSymbol`.
+
+```swift
+.confettiCannon(
+    trigger: $trigger,
+    confettis: [
+        .assetSymbol(symbolName: "custom.badge"),
+        .assetSymbol(symbolName: "custom.badge.fill")
+    ],
+    colors: [.blue, .cyan],
+    confettiSize: 20
+)
+```
+
 ## 👨‍💻 Contributors
 
 All issue reports, feature requests, pull requests and GitHub stars are welcomed and much appreciated.

--- a/Sources/ConfettiSwiftUI.swift
+++ b/Sources/ConfettiSwiftUI.swift
@@ -20,10 +20,14 @@ public enum ConfettiType:CaseIterable, Hashable {
     case shape(Shape)
     case text(String)
     case sfSymbol(symbolName: String)
+    /// Loads a custom symbol asset from the host app's asset catalog.
+    case assetSymbol(symbolName: String)
     case image(String)
     
     public var view:AnyView{
         switch self {
+        case .shape(.circle):
+            return AnyView(Circle())
         case .shape(.square):
             return AnyView(Rectangle())
         case .shape(.triangle):
@@ -36,10 +40,27 @@ public enum ConfettiType:CaseIterable, Hashable {
             return AnyView(Text(text))
         case .sfSymbol(let symbolName):
             return AnyView(Image(systemName: symbolName))
+        case .assetSymbol(let symbolName):
+            return AnyView(Image(symbolName))
         case .image(let image):
             return AnyView(Image(image).resizable())
-        default:
-            return AnyView(Circle())
+        }
+    }
+
+    func styledView(color: Color, confettiSize: CGFloat) -> AnyView {
+        switch self {
+        case .shape:
+            return AnyView(
+                view
+                    .foregroundColor(color)
+                    .frame(width: confettiSize, height: confettiSize, alignment: .center)
+            )
+        case .image:
+            return AnyView(view.frame(maxWidth: confettiSize, maxHeight: confettiSize))
+        case .text, .sfSymbol, .assetSymbol:
+            // Asset-catalog symbol images should stay on the symbol styling path so
+            // they respond to the same font and tint configuration as system symbols.
+            return AnyView(view.foregroundColor(color).font(.system(size: confettiSize)))
         }
     }
     
@@ -94,14 +115,7 @@ public struct ConfettiCannon<T: Equatable>: View {
         
         for confetti in confettis{
             for color in colors{
-                switch confetti {
-                case .shape(_):
-                    shapes.append(AnyView(confetti.view.foregroundColor(color).frame(width: confettiSize, height: confettiSize, alignment: .center)))
-                case .image(_):
-                    shapes.append(AnyView(confetti.view.frame(maxWidth:confettiSize, maxHeight: confettiSize)))
-                default:
-                    shapes.append(AnyView(confetti.view.foregroundColor(color).font(.system(size: confettiSize))))
-                }
+                shapes.append(confetti.styledView(color: color, confettiSize: confettiSize))
             }
         }
     

--- a/Tests/ConfettiSwiftUITests/ConfettiSwiftUITests.swift
+++ b/Tests/ConfettiSwiftUITests/ConfettiSwiftUITests.swift
@@ -4,16 +4,25 @@ import XCTest
 import SwiftUI
 
 final class ConfettiSwiftUITests: XCTestCase {
-    @State var trigger = false
+    @State private var trigger = false
 
-    func testExample() {
-        ConfettiSwiftUI.ConfettiCannon(trigger: $trigger)
-        Button("Animation"){
+    func testConfettiCannonSupportsAllContentKinds() {
+        _ = ConfettiSwiftUI.ConfettiCannon(
+            trigger: $trigger,
+            confettis: [
+                .shape(.circle),
+                .text("🎉"),
+                .sfSymbol(symbolName: "star.fill"),
+                .assetSymbol(symbolName: "custom.symbol"),
+                .image("custom-image")
+            ]
+        )
+        _ = Button("Animation") {
             self.trigger.toggle()
         }
     }
 
     static var allTests = [
-        ("testExample", testExample),
+        ("testConfettiCannonSupportsAllContentKinds", testConfettiCannonSupportsAllContentKinds),
     ]
 }


### PR DESCRIPTION
### Description

This adds a small new enum case, `assetSymbol(symbolName:)`, for custom symbol images that come from an app’s asset catalog.

I ran into a case where I wanted confetti pieces to use custom symbol assets and still respond to the same color and size styling that `.sfSymbol(symbolName:)` already gets. The existing `.sfSymbol(...)` path only works with system symbols, and `.image(...)` can load asset images but treats them more like plain images, so it doesn’t get the same tinting/font-based symbol styling.

This new case keeps the API explicit and makes the intended use clearer:

- use `.sfSymbol(...)` for system symbols
- use `.assetSymbol(...)` for custom symbol assets
- use `.image(...)` for regular images

(I also updated the existing package test so swift test runs cleanly under current Swift/Xcode tooling without the unused-result / explicit-self warnings.)

### Related Issues

No related issue for this one. This came up from a real app integration using custom symbol assets for confetti.

### Checklist

- [x] Have you added tests where necessary? Do all the test pass? 
- [x] Have you added descriptive comments to your code?
- [x] Have you updated the documentation related to this proposal?